### PR TITLE
Hibzz Hibernator v1.1 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # Hibzz.Hibernator
  A library used to create low performant idle applications in Unity
 
-### Installation
+**Without Hibernator**
+
+![image](https://user-images.githubusercontent.com/37605842/169102028-5f13ad7d-8c4c-4934-80d8-ed9698bdfe7a.png)
+
+**With Hibernator**
+
+![image](https://user-images.githubusercontent.com/37605842/169102077-b522b8b3-dd25-4953-aa97-28d9548c9fc3.png)
+
+<br>
+
+## Installation
 **Via NPM**
 This package is published to the NPM registery, so users can install and get updates directly in the Unity Package Manager when the package is installed via NPM.
 - Navigate to the advanced project settings menu in the Unity Package Manager
@@ -15,10 +25,9 @@ This package can be installed in the Unity Package Manager using the following g
 https://github.com/Hibzz-Games/Hibzz.Hibernator.git
 ```
 
-### Performance Benefits
-\<image goes here>
+<br>
 
-### Usage
+## Usage
 Initializing the Hibernator
 ```c#
 using Hibzz.Hibernator;
@@ -61,6 +70,8 @@ public class RotateClass : MonoBehavior
     }
 }
 ```
+
+<br>
 
 ### Optional Features
 While refreshing the hibernator, users can optionally give a time and the system will keep refreshing for the given time. This time is scalable by Time.TimeScale.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
 # Hibzz.Hibernator
  A library used to create low performant idle applications in Unity
 
+### Installation
+**Via NPM**
+This package is published to the NPM registery, so users can install and get updates directly in the Unity Package Manager when the package is installed via NPM.
+- Navigate to the advanced project settings menu in the Unity Package Manager
+- Create a new scoped registry with the URL `https://registry.npmjs.org`
+- Add `com.hibzz.hibernator` as scope
+- Now you'll be able to view and install the package under the "My Registeries" in the Package Manager.
+
+**Via Github**
+This package can be installed in the Unity Package Manager using the following git URL.
+```
+https://github.com/Hibzz-Games/Hibzz.Hibernator.git
+```
+
 ### Usage
+Initializing the Hibernator
 ```c#
-// Initializing the Hibernator
 using Hibzz.Hibernator;
 
 public class GameManager : MonoBehavior
@@ -25,8 +39,8 @@ public class GameManager : MonoBehavior
 }
 ```
 
+Refreshing Graphics
 ```c#
-// Refreshing graphics
 using Hibzz.Hibernator;
 
 public class RotateClass : MonoBehavior

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This package can be installed in the Unity Package Manager using the following g
 https://github.com/Hibzz-Games/Hibzz.Hibernator.git
 ```
 
+### Performance Benefits
+\<image goes here>
+
 ### Usage
 Initializing the Hibernator
 ```c#
@@ -24,11 +27,12 @@ public class GameManager : MonoBehavior
 {
     void start()
     {
-        // How long (in seconds) should the system wait for refresh while hibernating? Here we wait for an hour!
-        Hibernator.Instance.RenderFrequency = 3600.0f; 
-
         // Start the system
         Hibernator.Instance.Begin();
+
+        // Optionally, you can specify render interval. Here, the screen is 
+        // refreshed once every 15 seconds
+        Hibernator.Instance.Begin(15.0f);
     }
 
     void OnDestroy()

--- a/Scripts/Core/Hibernator.cs
+++ b/Scripts/Core/Hibernator.cs
@@ -13,11 +13,11 @@ namespace Hibzz.Hibernator
 		public float RenderFrequency 
 		{
 			get { return renderFrequency; } 
-			set 
+			private set 
 			{
 				renderFrequency = value;
 				renderInterval = CalculateRenderInterval(value);
-			} 
+			}
 		}
 
 		// how frequently should the screen refresh (in seconds)
@@ -35,10 +35,22 @@ namespace Hibzz.Hibernator
 		/// <summary>
 		/// Start the hibernator
 		/// </summary>
-		public void Begin()
+		public void Begin(float? renderFrequency = null)
 		{
 			isRunning = true;
 			time = 0.5f; // some small value greater than delta time for initial graphincs buffering
+
+			// If a render frequency is not given, then set it to maximum
+			if(renderFrequency == null)
+            {
+				this.renderFrequency = float.PositiveInfinity;
+				renderInterval = int.MaxValue;
+			}
+			else
+            {
+				// has a value, so set it
+				RenderFrequency = renderFrequency.Value;
+            }
 		}
 
 		/// <summary>
@@ -86,7 +98,7 @@ namespace Hibzz.Hibernator
 				frameRate = 1 / Time.deltaTime;
 			}
 
-			return Mathf.FloorToInt(frameRate * renderFrequency);
+			return Mathf.FloorToInt(frameRate * frequency);
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
     "email": "support@hibzz.games",
     "url": "https://hibzz.games/"
   },
+  "documentationUrl": "https://github.com/Hibzz-Games/Hibzz.Hibernator/blob/main/README.md",
+  "changelogUrl": "https://github.com/Hibzz-Games/Hibzz.Hibernator/commits/",
+  "licensesUrl":"https://github.com/Hibzz-Games/Hibzz.Hibernator/blob/main/LICENSE",
   "type": "library"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hibzz.hibernator",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "displayName": "hibzz.hibernator",
   "description": "A library used to create low performant idle applications in Unity",
   "author": {
@@ -10,6 +10,6 @@
   },
   "documentationUrl": "https://github.com/Hibzz-Games/Hibzz.Hibernator/blob/main/README.md",
   "changelogUrl": "https://github.com/Hibzz-Games/Hibzz.Hibernator/commits/",
-  "licensesUrl":"https://github.com/Hibzz-Games/Hibzz.Hibernator/blob/main/LICENSE",
+  "licensesUrl": "https://github.com/Hibzz-Games/Hibzz.Hibernator/blob/main/LICENSE",
   "type": "library"
 }


### PR DESCRIPTION
### Made some critical changes including:
- `Hibernator.Begin()` now can optionally accept RenderFrequency as an input parameter
- `Hibernator.RenderFrequency` is no longer a publically settable property
- By default, the RenderFrequency is set to max

### Known issues
- ~~I have noticed an increase in CPU usage when the hibernator is enabled. A minor uptick in the CPU usage was expected, but the 5% to 30% CPU usage was not. I need to profile and check what's causing the increase.~~

EDIT: Nvm, I'm a dumbo... So that jump in CPU usage, I think I have a theory. Because I didn't set a target framerate in my test scene, as soon as the GPU is freed, the CPU is no longer bottlenecked and runs with the highest framerate it can.

EDIT 2: Tried setting fixed framerate to 60 FPS and disabled v-sync and got consistent result for the CPU. So, my theory was right!!! 